### PR TITLE
fix: strip __ST_ENC__: prefix before decrypting appSecret in generateAppToken

### DIFF
--- a/apps/web/actions/app.ts
+++ b/apps/web/actions/app.ts
@@ -58,10 +58,7 @@ export const generateAppToken = async (
     },
   };
 
-  const encryptedSecret = row.appSecret.startsWith(SENSITIVE_KEY_PREFIX)
-    ? row.appSecret.slice(SENSITIVE_KEY_PREFIX.length)
-    : row.appSecret;
-  const rawToken = signJwt(context, "1h", decrypt(encryptedSecret), STELLARTOOLS_ID);
+  const rawToken = signJwt(context, "1h", decrypt(row.appSecret.slice(SENSITIVE_KEY_PREFIX.length)), STELLARTOOLS_ID);
   const token = `${APP_TOKEN_PREFIX}${rawToken}`;
 
   return token;

--- a/apps/web/actions/app.ts
+++ b/apps/web/actions/app.ts
@@ -58,7 +58,7 @@ export const generateAppToken = async (
     },
   };
 
-  const rawToken = signJwt(context, "1h", decrypt(row.appSecret.slice(SENSITIVE_KEY_PREFIX.length)), STELLARTOOLS_ID);
+  const rawToken = signJwt(context, "1h", decrypt(row.appSecret.replaceAll(SENSITIVE_KEY_PREFIX, "")), STELLARTOOLS_ID);
   const token = `${APP_TOKEN_PREFIX}${rawToken}`;
 
   return token;

--- a/apps/web/actions/app.ts
+++ b/apps/web/actions/app.ts
@@ -58,7 +58,10 @@ export const generateAppToken = async (
     },
   };
 
-  const rawToken = signJwt(context, "1h", decrypt(row.appSecret), STELLARTOOLS_ID);
+  const encryptedSecret = row.appSecret.startsWith(SENSITIVE_KEY_PREFIX)
+    ? row.appSecret.slice(SENSITIVE_KEY_PREFIX.length)
+    : row.appSecret;
+  const rawToken = signJwt(context, "1h", decrypt(encryptedSecret), STELLARTOOLS_ID);
   const token = `${APP_TOKEN_PREFIX}${rawToken}`;
 
   return token;


### PR DESCRIPTION
postApp stores appSecret in the DB as __ST_ENC__:<encrypted_bytes> — the prefix is a storage marker, not part of the encrypted data. generateAppToken was passing the full prefixed string directly into decrypt(), which broke IV/auth-tag parsing and caused GCM decryption to fail.

This worked in dev only because those app records were seeded before the prefix convention was applied to appSecret. In production, all apps go through postApp, so the prefix is always present, making token generation silently fail on every webhook delivery.